### PR TITLE
set bit ENABLE_VIRTUAL_TERMINAL_PROCESSING in Windows

### DIFF
--- a/src/M_escape.f90
+++ b/src/M_escape.f90
@@ -168,12 +168,14 @@
 module M_escape
 use M_list2, only : insert, locate, replace, remove
 use, intrinsic :: iso_fortran_env, only : stderr=>ERROR_UNIT,stdin=>INPUT_UNIT    ! access computing environment
+use, intrinsic :: iso_c_binding, only: c_int
 implicit none
 private
 public esc
 public esc_mode
 public update
 public print_dictionary
+public M_escape_initialize
 
 !-!public flush_colors, init_colors
 public attr
@@ -264,6 +266,12 @@ character(len=*),parameter,public :: ununderline =  CODE_START//UNDERLINE_OFF//C
 character(len=*),parameter,public :: reset       =  CODE_RESET
 character(len=*),parameter,public :: clear       =  HOME_DISPLAY//CLEAR_DISPLAY
 
+interface
+    function M_escape_initialize() result(r) bind(c, name="M_escape_initialize")
+        import c_int
+        integer(kind=c_int) :: r
+    end function
+end interface
 
 contains
 !===================================================================================================================================

--- a/src/M_escape_initialize.c
+++ b/src/M_escape_initialize.c
@@ -1,0 +1,31 @@
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+int M_escape_initialize(void)
+{
+    HANDLE h_stdout;
+    DWORD mode;
+
+    h_stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (h_stdout == INVALID_HANDLE_VALUE)
+        return -1;
+
+    if (! GetConsoleMode(h_stdout, &mode))
+        return -2;
+
+    mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if (! SetConsoleMode(h_stdout, mode))
+        return -3;
+
+    return 0;
+}
+
+#else
+
+int M_escape_initialize(void)
+{
+    return 0;
+}
+
+#endif

--- a/test/win32.f90
+++ b/test/win32.f90
@@ -1,0 +1,10 @@
+program win32
+use M_escape, only: fg_red, bg_default, bold, reset, M_escape_initialize
+use, intrinsic :: iso_c_binding, only: c_int
+implicit none
+integer(kind=c_int) :: i
+
+i = M_escape_initialize()
+print *, fg_red, bg_default, bold, 'Hello!', reset
+
+end program


### PR DESCRIPTION
Hi @urbanjost. This PR enables Terminal Colors in Windows. The function `M_escape_initialize()` enables `ENABLE_VIRTUAL_TERMINAL_PROCESSING`  in Windows [1]. In linux, it has no effect. Solves [2]

[1] https://docs.microsoft.com/en-us/windows/console/setconsolemode
[2] https://user-images.githubusercontent.com/5913872/112230673-0705fe80-8c14-11eb-91da-3a3405d0fa67.png